### PR TITLE
Add GitHub Skills activity to course offerings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing **GitHub Skills** activity that was announced by the principal during the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Activity description highlights the partnership with GitHub and the Certifications program
- Schedule: Mondays and Thursdays, 3:30 PM - 5:00 PM
- Maximum capacity: 25 students
- Ready for immediate student registration

## Why This is Important
- **Time-sensitive**: Registration deadline is end of this week
- Students have been unable to sign up since the announcement
- Part of GitHub Certifications program to help with college applications
- Addresses immediate student need

Fixes #6